### PR TITLE
Add administrators to lpadmin by default

### DIFF
--- a/debian/patches/default-groups.patch
+++ b/debian/patches/default-groups.patch
@@ -1,19 +1,20 @@
-Description: Add the adm group to new administrator accounts
+Description: Add the adm and lpadmin groups to new administrator accounts
  .
  accountsservice (0.6.50-0ubuntu1~pop1) disco; urgency=medium
  .
    * Add the adm group to new administrator accounts
 Author: Michael Aaron Murphy <michael@system76.com>
 
-Index: accountsservice-0.6.55/src/daemon.c
+Index: accountsservice/src/daemon.c
 ===================================================================
---- accountsservice-0.6.55.orig/src/daemon.c
-+++ accountsservice-0.6.55/src/daemon.c
-@@ -1136,6 +1136,7 @@ daemon_create_user_authorized_cb (Daemon
+--- accountsservice.orig/src/daemon.c
++++ accountsservice/src/daemon.c
+@@ -1136,6 +1136,8 @@ daemon_create_user_authorized_cb (Daemon
          }
  
          if (cd->account_type == ACCOUNT_TYPE_ADMINISTRATOR) {
 +                add_user_to_group(context, cd->user_name, "adm");
++                add_user_to_group(context, cd->user_name, "lpadmin");
                  add_user_to_group (context, cd->user_name, "sudo");
          }
  

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,4 +12,4 @@
 act-user-manager-Watch-for-the-daemon-going-away-and-comi.patch
 
 # Pop!_OS Patches
-adm-group.patch
+default-groups.patch


### PR DESCRIPTION
We already patch accountsservice to add users to `adm` in addition to the default `sudo` group. This PR adds `lpadmin` to the list of groups a new administrator account is added to by default. (This applies to the default account created by GNOME Initial Setup, and additional accounts created using GNOME Control Center.)

I opted to rename our existing patch and add an additional line, rather than creating an additional patch file. The spacing on the new `lpadmin` line matches the spacing that was already on the `adm` line.

This will close the following issues:
https://github.com/pop-os/gnome-initial-setup/issues/54 
https://github.com/pop-os/pop/issues/655 
https://github.com/pop-os/pop/issues/811 
https://github.com/pop-os/pop/issues/1262 

I also saw this file in distinst: https://github.com/pop-os/distinst/blob/master/src/installer/steps/configure/chroot_conf.rs#L139 That one doesn't appear to do anything for the end user. This accountsservice change alone affected the default user, but the distinst change alone did not affect the default user.